### PR TITLE
test-for-tk.tcl improvements

### DIFF
--- a/test-for-tk.tcl
+++ b/test-for-tk.tcl
@@ -1,6 +1,8 @@
-package require Tk
-puts {ok1}
-puts $tcl_version
-package require snit
-puts {ok2}
+if {![catch {package require Tk}]} {
+    puts {ok1}
+    puts $tcl_version
+}
+if {![catch {package require snit}]} {
+    puts {ok2}
+}
 exit

--- a/test-for-tk.tcl
+++ b/test-for-tk.tcl
@@ -5,4 +5,7 @@ if {![catch {package require Tk}]} {
 if {![catch {package require snit}]} {
     puts {ok2}
 }
+if {![catch {package require tklib}]} {
+    puts {ok3}
+}
 exit


### PR DESCRIPTION
Two commits:
1. use `catch {package require …}` so that if a package is missing, there isn't a fatal error that causes the remaining package tests to be skipped and in turn cause Makefile.PL to report Tcl/Tk packages as missing even if they're present.
2. add a test for tklib, which Makefile.PL was already expecting: https://github.com/vadrer/perl-tcl-tk/blob/2c0ab2e6380c1d6fecb04381e20e2bef5df146a8/Makefile.PL#L60-L66