### PR TITLE
Makefile.PL: update META_MERGE

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -73,8 +73,13 @@ WriteMakefile(
     MIN_PERL_VERSION => '5.006',
     ABSTRACT_FROM => 'lib/Tcl/Tk.pm',
     META_MERGE => {
+        "meta-spec" => { version => 2 },
         resources => {
-            repository => 'http://github.com/vadrer/perl-tcl-tk',
+            repository => {
+                type => 'git',
+                web => 'https://github.com/vadrer/perl-tcl-tk',
+                url => 'https://github.com/vadrer/perl-tcl-tk.git',
+            },
             MailingList => 'mailto:tcltk@perl.org',
         },
 	no_index => {


### PR DESCRIPTION
Cf. example at https://perldoc.perl.org/ExtUtils/MakeMaker.html#META_MERGE

- use meta spec version 2
- use Map, HTTPS URLs for repository