### PR TITLE
Tk.pm: fix typo

### DIFF
--- a/lib/Tcl/Tk.pm
+++ b/lib/Tcl/Tk.pm
@@ -1750,7 +1750,7 @@ sub _addcascade {
     $mnu->add('cascade',%args);
     return $smnu;
 }
-# internal helper sub to process perlTk's -menuitmes option
+# internal helper sub to process perlTk's -menuitems option
 sub _process_menuitems {
     my ($int,$mnu,$mis) = @_;
     for (@$mis) {


### PR DESCRIPTION
(the same typo was in Tcl::pTk)