### PR TITLE
Add initial Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: perl
+
+sudo: required
+
+install:
+    - sudo apt-get -y install tklib libtk-img xvfb
+    - xvfb-run -a cpanm --installdeps . || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - xvfb-run -a perl Makefile.PL
+    - xvfb-run -a make test
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+    - "5.10"


### PR DESCRIPTION
Travis-CI is a continuous integration service which is free for open
source projects.  This change adds an initial configuration for
this service.  Note that xvfb is used to handle the fact that Travis CI
is a headless environment and that one needs to use the `-a` flag to
`xvfb-run` in order that the `xvfb` server is automatically started,
which then allows the dist to build and test reliably on this
infrastructure.