### PR TITLE
Fix tklib detection

### DIFF
--- a/test-for-tk.tcl
+++ b/test-for-tk.tcl
@@ -5,7 +5,8 @@ if {![catch {package require Tk}]} {
 if {![catch {package require snit}]} {
     puts {ok2}
 }
-if {![catch {package require tklib}]} {
+# detect tklib existence ('cursor' is a package in tklib)
+if {![catch {package require cursor}]} {
     puts {ok3}
 }
 if {![catch {package require tile}]} {


### PR DESCRIPTION
As mentioned in RT#125850, the check for tklib's existence can fail even
if the library has been installed.  This change tests for the existence
of the `cursor` tklib package which was part of the initial tklib import
commit (https://core.tcl.tk/tklib/info/ec23b04ac240ca3c) and still
exists in the library, hence this check should now be fairly robust and
backwards compatible over (hopefully) all versions of tklib.