### PR TITLE
Set Perl minimum version explicitly

### DIFF
--- a/lib/Tcl/Tk.pm
+++ b/lib/Tcl/Tk.pm
@@ -1,6 +1,7 @@
 package Tcl::Tk;
 
 use strict;
+use 5;
 use Tcl;
 use Exporter 'import';
 use vars qw(@EXPORT_OK %EXPORT_TAGS);


### PR DESCRIPTION
While checking the Perl minimum version value I found that some of the demo scripts were using an explicit version that was below that which was set in the `Makefile.PL`.  Also, I noticed that although a minimum Perl version was set in the `Makefile.PL` (and hence in the dist's metadata), it wasn't actually set in the dist's main package.  The commits in this PR bump the Perl version in the demo scripts to match that set in the dist's metadata and set the minimum version explicitly in the dist's main package so that the dist's code is consistent with its metadata.

If you'd like me to change or update anything, just let me know and I'll update and resubmit as necessary.