### PR TITLE
Replace hardcoded shebang perl path with perl from env

### DIFF
--- a/tk-demos/widget
+++ b/tk-demos/widget
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl -w
+#!/usr/bin/perl
 
 require 5.004;
 

--- a/tk-demos/widtrib/npuz.pl
+++ b/tk-demos/widtrib/npuz.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 # A N-puzzle implemented via the Grid geometry manager.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 4 of
@@ -5,7 +6,6 @@
 # distribution with permission.  It has been modified slightly to conform
 # to the widget demo standard.
 
-#!/usr/local/bin/perl -w
 #
 # puz - demonstrate the Grid geometry manager by implementing an n-puzzle.
 #

--- a/tk-demos/widtrib/plop.pl
+++ b/tk-demos/widtrib/plop.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl
 # Plot a series of continuous functions on a Perl/Tk Canvas.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 1 of
@@ -5,7 +6,6 @@
 # distribution with permission.  It has been modified slightly to conform
 # to the widget demo standard.
 
-#!/usr/local/bin/perl -w
 #
 # plot_program - plot a series of continuous functions on a Perl/Tk Canvas.
 #


### PR DESCRIPTION
Not all systems have perl installed under /usr/local; using the perl
from the environment will hence work more reliably.

Also, the shebang line should be in the first line of the script (see e.g. https://en.wikipedia.org/wiki/Shebang_(Unix)#History) ; I've thus moved the shebang lines that I've changed here that weren't at the top of the file to the top.