### PR TITLE
Fix stale links

### DIFF
--- a/tk-demos/widtrib/HList2.pl
+++ b/tk-demos/widtrib/HList2.pl
@@ -9,8 +9,7 @@
 # This program is free software; you can redistribute it and/or
 # modify it under the same terms as Perl itself.
 #
-# Mail: eserte@cs.tu-berlin.de
-# WWW:  http://user.cs.tu-berlin.de/~eserte/
+# WWW: https://github.com/eserte
 #
 
 use Tk::HList;

--- a/tk-demos/widtrib/npuz.pl
+++ b/tk-demos/widtrib/npuz.pl
@@ -1,9 +1,9 @@
 # A N-puzzle implemented via the Grid geometry manager.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 4 of
-# The Perl Journal (http://tpj.com/tpj), and is included in the Perl/Tk
-# distribution with permission.  It has been modified slightly to conform
-# to the widget demo standard.
+# The Perl Journal, and is included in the Perl/Tk distribution with
+# permission.  It has been modified slightly to conform to the widget demo
+# standard.
 
 #!/usr/local/bin/perl -w
 #

--- a/tk-demos/widtrib/plop.pl
+++ b/tk-demos/widtrib/plop.pl
@@ -1,9 +1,9 @@
 # Plot a series of continuous functions on a Perl/Tk Canvas.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 1 of
-# The Perl Journal (http://tpj.com/tpj), and is included in the Perl/Tk
-# distribution with permission.  It has been modified slightly to conform
-# to the widget demo standard.
+# The Perl Journal, and is included in the Perl/Tk distribution with
+# permission.  It has been modified slightly to conform to the widget demo
+# standard.
 
 #!/usr/local/bin/perl -w
 #


### PR DESCRIPTION
I noticed that some of the URLs were out of date; these commits either remove or update the stale links.  

In the case of the link to The Perl Journal, I decided to remove the link entirely since it didn't seem appropriate to redirect the link to an internet archive link and because the site for the journal no longer exists.

In the case of the link to `eserte`'s web address, I found that the site no longer exists (it looks like that's where he went to university), however he's still an active Perl programmer, hence I updated the web link to his GitHub page.  If you want, I could remove this link as well, as it might not be necessary (or useful) to keep such links on a long term basis.  Anyway, let me know what you think and I'll update and resubmit as necessary.