### PR TITLE
Replace barewords with lexicals

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,8 +42,8 @@ EOT
 
 
 if ($test_for_tk) {
-    open TCLSH, "$tclsh test-for-tk.tcl|";
-    my $res = join '', <TCLSH>;
+    open my $tk_test, "$tclsh test-for-tk.tcl|";
+    my $res = join '', <$tk_test>;
 
     unless ($res =~ /^ok1/m) {
         _die <<EOS;

--- a/tk-demos/widget
+++ b/tk-demos/widget
@@ -270,15 +270,16 @@ unshift @dirent, 'TEMPLATE.pl';	# I want it first
 my $i = 0;
 while ($_ = shift @dirent) {
     next if /TEMPLATE\.pl/ and $i != 0;
-    unless (open(C, "$WIDTRIB/$_")) {
+    my $fh;
+    unless (open($fh, "$WIDTRIB/$_")) {
 	warn "Cannot open $_: $!" unless /TEMPLATE\.pl/;
 	next;
     }
     my($name) = /^(.*)\.pl$/;
-    $_ = <C>;
+    $_ = <$fh>;
     my($title) = /^#\s*(.*)$/;
     $DEMO_DESCRIPTION{$name} = $title;
-    close C;
+    close $fh;
     $T->insert('end', ++$i . ". $title\n", ['demo', "demo-$name"]);
 }
 
@@ -397,12 +398,12 @@ sub see_code {
     $file = "$widget_lib/${demo}.pl" if -f "$widget_lib/${demo}.pl";
     $CODE->title("Demo code: $file");
     $CODE_TEXT->delete(qw/1.0 end/);
-    open(CODE, "<$file") or warn "Cannot open demo file $file: $!";
+    open(my $code, "<$file") or warn "Cannot open demo file $file: $!";
     {
 	local $/ = undef;
-	$CODE_TEXT->insert('1.0', <CODE>);
+	$CODE_TEXT->insert('1.0', <$code>);
     }
-    close CODE;
+    close $code;
     $CODE_TEXT->markSet(qw/insert 1.0/);
 
 } # end see_code
@@ -487,12 +488,12 @@ sub view_widget_code {
     $VIEW->title("Demo code: $widget");
     $VIEW_TEXT->configure(qw/-state normal/);
     $VIEW_TEXT->delete(qw/1.0 end/);
-    open(VIEW, "<$widget") or warn "Cannot open demo file $widget: $!";
+    open(my $widget_fh, "<$widget") or warn "Cannot open demo file $widget: $!";
     {
 	local $/ = undef;
-	$VIEW_TEXT->insert('1.0', <VIEW>);
+	$VIEW_TEXT->insert('1.0', <$widget_fh>);
     }
-    close VIEW;
+    close $widget_fh;
     $VIEW_TEXT->markSet(qw/insert 1.0/);
     $VIEW_TEXT->configure(qw/-state disabled/);
 

--- a/tk-demos/widget
+++ b/tk-demos/widget
@@ -263,9 +263,9 @@ $T->insert('end', "3. A dialog box with a global grab.\n",
     [qw/demo demo-dialog2/]);
 
 $T->insert('end', "\n", '', "User Contributed Demonstrations\n", 'title');
-opendir(C, $WIDTRIB) or warn "Cannot open $WIDTRIB: $!";
-my(@dirent) = grep /^.+\.pl$/, sort(readdir C);
-closedir C;
+opendir(my $dir, $WIDTRIB) or warn "Cannot open $WIDTRIB: $!";
+my(@dirent) = grep /^.+\.pl$/, sort(readdir $dir);
+closedir $dir;
 unshift @dirent, 'TEMPLATE.pl';	# I want it first
 my $i = 0;
 while ($_ = shift @dirent) {

--- a/tk-demos/widget_lib/image2.pl
+++ b/tk-demos/widget_lib/image2.pl
@@ -71,12 +71,11 @@ sub image2_load_dir {
 
     $l->delete(0, 'end');
     my $i;
-    local *DIR;
-    opendir DIR, $$dir_name;
-    foreach $i (sort readdir DIR) {
+    opendir my $dir, $$dir_name;
+    foreach $i (sort readdir $dir) {
        $l->insert('end', $i);
     }
-    closedir DIR;
+    closedir $dir;
 
 } # end image2_load_dir
 

--- a/tk-demos/widget_lib/mkTxtSearch.pl
+++ b/tk-demos/widget_lib/mkTxtSearch.pl
@@ -12,17 +12,18 @@ sub text_load_file {
 
     my ($buf, $bytes) = ('', 0);
 
-    if (not open(F, "<$file")) {
+    my $fh;
+    if (not open($fh, "<$file")) {
 	$top->Dialog('File Not Found', $!, 'error', 'OK', 'OK')->Show('-global');
 	return;
     }
     $w->delete('1.0', 'end');
-    $bytes = read F, $buf, 10000;	# after all, it IS just an example
+    $bytes = read $fh, $buf, 10000;	# after all, it IS just an example
     $w->insert('end', $buf);
     if ($bytes == 10000) {
 	$w->insert('end', "\n\n**************** File truncated at 10,000 bytes! ****************\n");
     }
-    close F;
+    close $fh;
 
 } # end text_load_file
 

--- a/tk-demos/widget_lib/search.pl
+++ b/tk-demos/widget_lib/search.pl
@@ -114,7 +114,8 @@ sub search_load_file {
 
     my ($buf, $bytes) = ('', 0);
 
-    if (not open(F, "<$$file")) {
+    my $fh;
+    if (not open($fh, "<$$file")) {
 	$MW->Dialog(
             -title  => 'File Not Found',
             -text   => $OS_ERROR,
@@ -123,12 +124,12 @@ sub search_load_file {
 	return;
     }
     $w->delete(qw/1.0 end/);
-    $bytes = read F, $buf, 10000;	# after all, it IS just an example
+    $bytes = read $fh, $buf, 10000;	# after all, it IS just an example
     $w->insert('end', $buf);
     if ($bytes == 10000) {
 	$w->insert('end', "\n\n**************** File truncated at 10,000 bytes! ****************\n");
     }
-    close F;
+    close $fh;
 
     $e->Subwidget('entry')->focus;
 

--- a/tk-demos/widtrib/HList.pl
+++ b/tk-demos/widtrib/HList.pl
@@ -49,9 +49,9 @@ sub select_all
 
 sub show_dir {
     my($entry_path, $text, $h) = @_;
-    opendir H, $entry_path;
-    my(@dirent) = grep ! /^\.\.?$/, sort(readdir H);
-    closedir H;
+    opendir my $dir, $entry_path;
+    my(@dirent) = grep ! /^\.\.?$/, sort(readdir $dir);
+    closedir $dir;
     $h->add($entry_path,  -text => $text, -image => $FOLDIMG, -data => 'DIR');
     while ($_ = shift @dirent) {
 	my $file = "$entry_path/$_";


### PR DESCRIPTION
One theoretically shouldn't use barewords in `open` or `opendir` commands anymore.  This patch updates the code to use lexicals instead as required by current Perl best practices.

As usual with my patches, if you want something changed, just let me know and I'll update and resubmit :-)