### PR TITLE
Simplify running tk test script at build time

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -42,8 +42,7 @@ EOT
 
 
 if ($test_for_tk) {
-    open TCLSH, "$tclsh test-for-tk.tcl|";
-    my $res = join '', <TCLSH>;
+    my $res = `$tclsh test-for-tk.tcl`;
 
     unless ($res =~ /^ok1/m) {
         _die <<EOS;


### PR DESCRIPTION
PR #23 there was a discussion which showed that using backticks was a better idea than opening a pipe.  This patch implements the change discussed in that other issue.