### PR TITLE
fix spelling/grammar in POD and comments

### DIFF
--- a/lib/Tcl/Tk.pm
+++ b/lib/Tcl/Tk.pm
@@ -163,7 +163,7 @@ provided a fact C<$button> corresponds to C<.fr.b> widget.
 C<use Tcl::Tk;> not only creates C<Tcl::Tk> package, but also it creates
 C<Tcl::Tk::Widget> package, responsible for widgets. Each widget (object
 blessed to C<Tcl::Tk::Widget>, or other widgets in ISA-relationship)
-behaves in such a way that its method will result in calling it's path on
+behaves in such a way that its method will result in calling its path on
 interpreter.
 
 =head3 Perl/Tk syntax

--- a/tk-demos/widget
+++ b/tk-demos/widget
@@ -346,7 +346,7 @@ sub invoke {
 
 sub lsearch {
 
-    # Search the list using the supplied regular expression and return it's
+    # Search the list using the supplied regular expression and return its
     # ordinal, or -1 if not found.
 
     my($regexp, @list) = @_;

--- a/tk-demos/widget_lib/ctext.pl
+++ b/tk-demos/widget_lib/ctext.pl
@@ -11,7 +11,7 @@ sub ctext {
     my($demo) = @_;
     $TOP = $MW->WidgetDemo(
         -name     => $demo,
-        -text     => ['This window displays a string of text to demonstrate the text facilities of canvas widgets.  You can click in the boxes to adijust the position of the text relative to its positioning point or change its justification.  The text also supports the following simple bindings for editing:
+        -text     => ['This window displays a string of text to demonstrate the text facilities of canvas widgets.  You can click in the boxes to adjust the position of the text relative to its positioning point or change its justification.  The text also supports the following simple bindings for editing:
   1. You can point, click, and type.
   2. You can also select with button 1.
   3. You can copy the selection to the mouse position with button 2.

--- a/tk-demos/widget_lib/floor.pl
+++ b/tk-demos/widget_lib/floor.pl
@@ -1338,7 +1338,7 @@ sub TIESCALAR {
 
 sub FETCH {
 
-    # Method to handle reads of the tied variable:  simply return it's value.
+    # Method to handle reads of the tied variable:  simply return its value.
 
     my($current_room) = @_;
     return $$current_room;
@@ -1347,7 +1347,7 @@ sub FETCH {
 
 sub STORE {
 
-    # Method to handle writes to the tied variable:  simply store it's value.
+    # Method to handle writes to the tied variable:  simply store its value.
     # Call floor_room_changed() to highlight a room, if possible.
 
     my($current_room, $value) = @_;

--- a/tk-demos/widtrib/Gedi.pl
+++ b/tk-demos/widtrib/Gedi.pl
@@ -238,7 +238,7 @@ TextUndo.pm
 =============
 
 TextUndo.pm is the second level module, being
-derived from the Text.pm module. As it's name
+derived from the Text.pm module. As its name
 implies, TextUndo supports "UNDO" capability.
 It now also supports "REDO" capability.
 


### PR DESCRIPTION
Some of these were in Tcl::pTk and are in Perl/Tk
https://github.com/chrstphrchvz/perl-tcl-ptk/commit/bcd6d4ea8376590e6f52b827642cab5e77d295f6