### PR TITLE
widget demo: use sub to show About dialog

### DIFF
--- a/tk-demos/widget
+++ b/tk-demos/widget
@@ -293,7 +293,7 @@ my $DIALOG_ABOUT = $MW->Dialog(
 		       "\nTk Version $Tk::VERSION\n\n      2000/07/07",
 );
 $help->cget(-menu)->entryconfigure('About',
-    -command => [$DIALOG_ABOUT => 'Show'],
+    -command => sub { $DIALOG_ABOUT->Show; },
 );
 
 my $DIALOG_ICON = $MW->Dialog(


### PR DESCRIPTION
Fixes `bad option "Show": must be cget or configure` error when opening About dialog:
![screen shot 2018-08-17 at 3 07 35 am](https://user-images.githubusercontent.com/7941193/44255237-f58e2780-a1ca-11e8-952b-2b9e54d2493b.png)


However, all that shows up is a window with an OK button, and not any text:
![tcltk widget about](https://user-images.githubusercontent.com/7941193/44255265-13f42300-a1cb-11e8-8d63-5109ce8b9c65.png)


Resized:
![bigger widget about](https://user-images.githubusercontent.com/7941193/44255271-18b8d700-a1cb-11e8-80e0-9b143cd4bda8.png)

And closing the dialog with the (e.g. close button on the title bar) rather than OK prevents the About dialog from being shown again:
```
Tcl error 'bad window path name ".dlgbox08" at /opt/local/lib/perl5/vendor_perl/5.26/darwin-thread-multi-2level/Tcl.pm line 795.
' while invoking scalar result call:
	"::tk::PlaceWindow .dlgbox08 pointer center" at /Users/christopherchavez/git/perl-tcl-tk/tk-demos/../blib/lib/Tcl/Tk.pm line 2007.

bad window path name ".dlgbox08"
    while executing
"wm withdraw $w"
    (procedure "::tk::PlaceWindow" line 2)
    invoked from within
"::tk::PlaceWindow .dlgbox08 pointer center"
    invoked from within
"::perl::CODE(0x7fde42249840)"
    (menu invoke)

``` 