### PR TITLE
Remove shebangs from contributed demos

### DIFF
--- a/tk-demos/widtrib/npuz.pl
+++ b/tk-demos/widtrib/npuz.pl
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 # A N-puzzle implemented via the Grid geometry manager.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 4 of

--- a/tk-demos/widtrib/plop.pl
+++ b/tk-demos/widtrib/plop.pl
@@ -1,4 +1,3 @@
-#!/usr/bin/perl
 # Plot a series of continuous functions on a Perl/Tk Canvas.
 #
 # This program is described in the Perl/Tk column from Volume 1, Issue 1 of


### PR DESCRIPTION
The first line of demos in widtrib is assumed to be a comment with the name of the demo (for displaying in the list of demos).

Before:
![screen shot 2018-08-17 at 3 19 06 am](https://user-images.githubusercontent.com/7941193/44255633-59fdb680-a1cc-11e8-90fa-2089d26bdee7.png)


After:
![screen shot 2018-08-16 at 8 55 05 pm](https://user-images.githubusercontent.com/7941193/44255588-39cdf780-a1cc-11e8-878b-89c962be5ff3.png)
